### PR TITLE
Fix: Register QOtp as a Component Instead of a Plugin

### DIFF
--- a/src/boot/register.js
+++ b/src/boot/register.js
@@ -2,5 +2,5 @@ import { boot } from 'quasar/wrappers'
 import QOtp from '../component/QOtp.vue'
 
 export default boot(({ app }) => {
-  app.use(QOtp)
+  app.component('QOtp', QOtp)
 })


### PR DESCRIPTION
Description:
The current implementation in src/boot/register.js uses app.use(QOtp) to register the QOtp component. However, since QOtp is a Vue component—not a plugin—it does not have an install method. This causes the following error when running the application:

```typescript
[Vue warn]: A plugin must either be a function or an object with an "install" function.
```

To fix this issue, the component should be registered globally with app.component('QOtp', QOtp) instead. This pull request updates the registration logic accordingly, ensuring that the QOtp component is correctly registered and the error is resolved.

I appreciate your review and look forward to any feedback or further suggestions.